### PR TITLE
Implemention of MQTT subscriber with topic mapping for SmartFields-camera trap integration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,22 @@ port = 2199
 cors_origin = "*"
 debug = false
 logfile_path = "logs/wildwings.txt"
+
+[subscriber]
+client_id = "local_subscriber"
+qos = 1
+broker = "localhost"
+port = 1883
+logfile_path = "logs/mqtt_subscriber.txt" 
+smartfields_url = "http://smartfields:2188/initiate_process"
+
+# MQTT topic mapping for each Pi
+[mqtt_topics."pi/001/events"]
+lat = 40.123
+lon = -83.654
+camid = "pi-001"
+
+[mqtt_topics."pi/002/events"]
+lat = 40.567
+lon = -83.321
+camid = "pi-002"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,32 @@ services:
       timeout: 10s
       retries: 3
 
+  mqtt:
+    image: eclipse-mosquitto:2
+    container_name: mqtt
+    ports:
+      - "1883:1883"
+    networks:
+      - smartfield-network
+    restart: unless-stopped
+
+  mqtt_subscriber:
+    build:
+      context: ./services/mqtt_subscriber
+      dockerfile: Dockerfile
+    container_name: mqtt_subscriber
+    depends_on:
+      - mqtt
+      - smartfield
+    volumes:
+      - ./config.toml:/app/config.toml:ro
+      - ./logs:/app/logs
+    networks:
+      - smartfield-network
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+
   loki:
     image: grafana/loki:2.9.0
     container_name: loki

--- a/services/mqtt_subscriber/Dockerfile
+++ b/services/mqtt_subscriber/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    make \
+    musl-dev \
+    libffi-dev \
+    openssl-dev \
+    linux-headers \
+    curl
+
+RUN pip install --upgrade pip setuptools wheel
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "subscriber.py"]

--- a/services/mqtt_subscriber/README.md
+++ b/services/mqtt_subscriber/README.md
@@ -1,0 +1,26 @@
+# TODO: Add content of this ReadMe into the main ReadMe file 
+
+# Smart Field MQTT Subscriber
+
+This service listens to camera trap event messages published via MQTT and triggers drone missions based on each camera’s GPS location.
+
+## What's this all about?
+
+In the field, multiple Raspberry Pi-based backpack camera traps detect wildlife activity. Each Pi publishes events (like new images captured) to its own MQTT topic.
+
+This service subscribes to those MQTT topics, maps each topic to a specific **GPS location**, and then calls the drone pipeline (`initiate_process`) with the correct coordinates. That way, a drone knows *exactly* where to fly next.
+
+---
+
+## How it Works
+
+1. Each Raspberry Pi publishes to a **unique MQTT topic**, like:
+pi/001/event1
+pi/002/event2
+
+2. This subscriber listens to all of them and uses a mapping config to determine:
+- Which Pi sent the event
+- What its latitude & longitude is
+- Which camera ID is associated
+
+3. Once an event is received, it automatically triggers the `/initiate_process` API of the **smartfields** service with the right GPS data.

--- a/services/mqtt_subscriber/requirements.txt
+++ b/services/mqtt_subscriber/requirements.txt
@@ -1,0 +1,3 @@
+paho-mqtt
+requests
+toml

--- a/services/mqtt_subscriber/subscriber.py
+++ b/services/mqtt_subscriber/subscriber.py
@@ -1,0 +1,87 @@
+import os
+import json
+import logging
+import paho.mqtt.client as mqtt
+import requests
+import toml
+from pathlib import Path
+
+config_path = Path("/app/config.toml")
+if not config_path.exists():
+    config_path = Path(__file__).parent.parent.parent / "config.toml"
+config = toml.load(config_path)
+
+sub_cfg = config.get("subscriber", {})
+topic_mappings = config.get("mqtt_topics", {})
+
+MQTT_BROKER = sub_cfg.get("broker", "localhost")
+MQTT_PORT = int(sub_cfg.get("port", 1883))
+CLIENT_ID = sub_cfg.get("client_id", "ckn_event_subscriber")
+SMARTFIELDS_API = sub_cfg.get("smartfields_url", "http://smartfields:2188/initiate_process")
+MQTT_QOS = int(sub_cfg.get("qos", 1))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(sub_cfg["logfile_path"]),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("mqtt_subscriber")
+
+def on_connect(client, userdata, flags, rc, properties=None):
+    if rc == 0:
+        logger.info("Connected to MQTT broker.")
+        for topic in topic_mappings.keys():
+            logger.info(f"Subscribing to topic: {topic}")
+            client.subscribe(topic, qos=MQTT_QOS)
+    else:
+        logger.error("Failed to connect with result code %d", rc)
+
+def on_message(client, userdata, msg):
+    topic = msg.topic
+    try:
+        mapping = topic_mappings.get(topic)
+        if not mapping:
+            logger.warning(f"Received message on unrecognized topic: {topic}")
+            return
+
+        payload = msg.payload.decode("utf-8")
+        data = json.loads(payload)
+
+        logger.info(f"Received event from topic {topic}:\n{json.dumps(data, indent=2)}")
+
+        lat = mapping["lat"]
+        lon = mapping["lon"]
+        camid = mapping["camid"]
+
+        response = requests.get(
+            SMARTFIELDS_API,
+            params={"lat": lat, "lon": lon, "camid": camid},
+            timeout=10
+        )
+
+        if response.status_code == 200:
+            logger.info(f"Triggered SmartFields pipeline for {camid} at ({lat}, {lon})")
+        else:
+            logger.error(f"Failed to trigger SmartFields pipeline: {response.status_code}, {response.text}")
+
+    except Exception as e:
+        logger.exception(f"Error processing message on topic {topic}: {e}")
+
+def main():
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=CLIENT_ID)
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+    try:
+        client.connect(MQTT_BROKER, MQTT_PORT, keepalive=60)
+    except Exception as e:
+        logger.exception(f"Could not connect to MQTT broker: {e}")
+        return
+
+    client.loop_forever()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a new MQTT subscriber service that listens to event topics published by Raspberry Pi-based camera traps. Based on the topic, it identifies the corresponding GPS location and camera ID and then triggers the SmartFields drone pipeline via /initiate_process.